### PR TITLE
Best/worst lines printer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The pie chart sizes will be divided based on how frequent the move is compared t
 
 ### Prerequisites
 - Runs in Python 3, must have Python 3 installed
-- Requires Plotly and pgnparser
+- Requires Plotly, pgnparser, pandas and numpy
 - To run as PyPI module, have this projects PyPI package installed
 
 You can install Plotly and pgnparser using PyPi, as long as you are an admin user on your device. To do so, simply type `pip install plotly` and `pip install pgnparser` into your terminal.
@@ -87,6 +87,10 @@ If you would like to simply run this code from Python IDE, then type `pip instal
   - The `color` argument. This is set to both by default. Valid inputs are 'both', 'white', 'w', 'black' and 'b'. If you change the `color` argument from both, then the program will only read games that are from the `color` you chose. Note that you need to also change the player name with the name argument if you do so. See below.
 
   - The `name` argument. This argument will allow the program to pick games from the file it is given, but only games from a certain player. There is an example below: Set the color to 'black' or 'white' to pick only games where the player (the name) played as black or white. (i.e. chess_graph.graph('pgns/Carlsen.pgn', color = 'white', name = 'Magnus Carlsen') will pick all the games where Carlsen played as white.)
+  
+  - The `print_best_lines` argument. This argument enables ('=True') the feature that allow you to print the best/worst line (computed taking into account the W/B ratio) for each semi-move  of the graph.
+  - The `min_games_best_lines` argument. This argument, set to 1 as default, requires a condition for the best/worst lines to have at least 'n' games. For example if it is set to 10 only lines with at least 10 games in the original database are taken into account for the best/worst line search. In case at a certain deph there are no lines with min_games_best_lines, an output message like this will appear: No lines at move ${depth} with at least ${min_games_best_lines} games
+
 
 **Remember to include all variations and parts of a player's name! For example, the player Viktor Korchnoi has his last name spelled as Kortschnoj as well. In that case, for the 'name' field, type: Viktor Korchnoi Kortschnoj**
 

--- a/chart.py
+++ b/chart.py
@@ -278,7 +278,7 @@ def best_worst(ids, labels, parents, values, percentage_everything, full_ratios,
             Best = best['ids'].values[0]
             b_score = best['full_ratios'].values[0]
             b_games = best['values'].values[0]
-            Worst = best['ids'].values[0]
+            Worst = worst['ids'].values[0]
             w_score = worst['full_ratios'].values[0]
             w_games = worst['values'].values[0]
     
@@ -289,7 +289,9 @@ def best_worst(ids, labels, parents, values, percentage_everything, full_ratios,
             print(out_warning)
 
     print('\n')
+    best_worst.set_index('move')
     print(best_worst)
+    print('\n')
 
 def graph(database, depth=5, shade = True, fragmentation_percentage=0.0032, should_defragment=False, custom_branching=False, should_download = False, download_format = 'png', download_name = 'fig1', color = 'both', name = '', print_best_lines=False, min_games_best_lines=1): # need file path, depth,
 

--- a/plotter.py
+++ b/plotter.py
@@ -1,0 +1,10 @@
+#import chess_graph
+from chart import graph
+
+#graph("pgns/lichess_Lorenzo_2012_2020-11-29.pgn", 
+graph("pgns/Carlsen.pgn", 
+                  depth=3, 
+                  shade = True, 
+                  fragmentation_percentage=0.10, 
+                  should_defragment=False,
+                  print_best_lines=True, min_games_best_lines=1) 

--- a/plotter.py
+++ b/plotter.py
@@ -3,8 +3,8 @@ from chart import graph
 
 #graph("pgns/lichess_Lorenzo_2012_2020-11-29.pgn", 
 graph("pgns/Carlsen.pgn", 
-                  depth=3, 
+                  depth=5, 
                   shade = True, 
                   fragmentation_percentage=0.10, 
                   should_defragment=False,
-                  print_best_lines=True, min_games_best_lines=1) 
+                  print_best_lines=True, min_games_best_lines=10) 


### PR DESCRIPTION
New optional feature implemented in chart.py .
Now the user can add:
```
print_best_lines=True
min_games_best_lines=10
```
The first line enable the feature while the second one tells how many games are required at least, for each semi-move, to select the best/worst line.
E.g. if min_games_best_lines is set equal to 10 only lines with at least 10 games in the original database are taken into account for the best/worst line search.
The number of best/worst lines printed will be equal to the number of semi-moves in the graph, hence equal to the `depth` value. 
In case at a certain deph there are no lines with `min_games_best_lines`, an output message like this will appear:
`No lines at move ${depth} with at least ${min_games_best_lines} games`

The new code need the import of two more libraries namely: pandas and numpy