### PR TITLE
Manage dependency versions using Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "00:00"
+    timezone: America/Chicago
+  open-pull-requests-limit: 10


### PR DESCRIPTION
GitHub's native Dependabot integration can manage dependency versions when security etc. patches become available.